### PR TITLE
Cleanup as()

### DIFF
--- a/benchmarks/src/main/scala/zio/parser/benchmarks/lucene/ZioLuceneQueryParser.scala
+++ b/benchmarks/src/main/scala/zio/parser/benchmarks/lucene/ZioLuceneQueryParser.scala
@@ -21,8 +21,8 @@ class ZioLuceneQueryParser(
       .transform(_.toString, (s: String) => s(0)) | escapedChar) ?? "term start"
   val termChar      = (termStartChar | Syntax.charIn('-', '+').transform(_.toString, (s: String) => s(0))) ?? "term char"
   val whitespace    = Syntax.charIn(whitespaceChars.toSeq: _*).unit(' ') ?? "whitespace"
-  val whitespaces   = whitespace.repeat0.printedAs((), Chunk(())) ?? "any whitespace"
-  val whitespaces1  = whitespace.repeat.printedAs((), Chunk(())) ?? "at least 1 whitespace"
+  val whitespaces   = whitespace.repeat0.asPrinted((), Chunk(())) ?? "any whitespace"
+  val whitespaces1  = whitespace.repeat.asPrinted((), Chunk(())) ?? "at least 1 whitespace"
   val quotedChar    =
     (Syntax.charNotIn('\"', '\\').transform(_.toString, (s: String) => s(0)) | escapedChar) ?? "quoted char"
 

--- a/zio-parser/src/main/scala/zio/parser/Printer.scala
+++ b/zio-parser/src/main/scala/zio/parser/Printer.scala
@@ -242,7 +242,7 @@ sealed trait Printer[+Err, +Out, -Value, +Result] { self =>
     self.map(_ => result)
 
   /** Ignores the printer's result and input and use 'result' and 'value' instead */
-  final def printedAs[Result2](result: Result2, value: Value): Printer[Err, Out, Result2, Result2] =
+  final def asPrinted[Result2](result: Result2, value: Value): Printer[Err, Out, Result2, Result2] =
     Printer.Ignore(self, result, value)
 
   /** Ignores the result of this printer and return unit instead */
@@ -411,7 +411,7 @@ object Printer {
   // Generic variants
   /** Printer that emits the given value */
   def apply[Out](value: => Out)(implicit ev: Out =!= Char): Printer[String, Out, Unit, Unit] =
-    exactly(value).printedAs((), value)
+    exactly(value).asPrinted((), value)
 
   /** Printer that emits the input if it is equals to 'value'. Otherwise fails */
   def exactly[Out](value: Out)(implicit ev: Out =!= Char): Printer[String, Out, Out, Out] =
@@ -472,7 +472,7 @@ object Printer {
 
   /** Prints a specific string 'str' and results in 'value' */
   def string[Result](str: String, value: Result): Printer[Nothing, Char, Result, Result] =
-    regexDiscard(Regex.string(str), Chunk.fromArray(str.toCharArray)).printedAs(value, ())
+    regexDiscard(Regex.string(str), Chunk.fromArray(str.toCharArray)).asPrinted(value, ())
 
   /** Printer that does not print anything and results in unit */
   def unit: Printer[Nothing, Nothing, Any, Unit] = succeed(())

--- a/zio-parser/src/main/scala/zio/parser/Syntax.scala
+++ b/zio-parser/src/main/scala/zio/parser/Syntax.scala
@@ -46,10 +46,10 @@ class Syntax[+Err, -In, +Out, -Value, +Result] private (
     )
 
   /** Sets the result to 'result' and the value to be printed to 'value' */
-  final def printedAs[Result2](result: Result2, value: Value): Syntax[Err, In, Out, Result2, Result2] =
+  final def asPrinted[Result2](result: Result2, value: Value): Syntax[Err, In, Out, Result2, Result2] =
     new Syntax(
       asParser.as(result),
-      asPrinter.printedAs(result, value)
+      asPrinter.asPrinted(result, value)
     )
 
   /** Maps the parser's successful result with the given function 'to', and maps the value to be printed with the given
@@ -367,7 +367,7 @@ class Syntax[+Err, -In, +Out, -Value, +Result] private (
   final def unit(printed: Value): Syntax[Err, In, Out, Unit, Unit] =
     new Syntax(
       self.asParser.unit,
-      self.asPrinter.printedAs((), printed)
+      self.asPrinter.asPrinted((), printed)
     )
 
   /** Converts a Chunk syntax to a List syntax */

--- a/zio-parser/src/main/scala/zio/parser/package.scala
+++ b/zio-parser/src/main/scala/zio/parser/package.scala
@@ -55,7 +55,7 @@ package object parser {
     def as[Result2](value: => Result2): Syntax[Err, In, Out, Result2, Result2] =
       Syntax.from(
         self.asParser.as(value),
-        self.asPrinter.printedAs(value, ())
+        self.asPrinter.asPrinted(value, ())
       )
   }
 

--- a/zio-parser/src/test/scala/zio/parser/ParserSpec.scala
+++ b/zio-parser/src/test/scala/zio/parser/ParserSpec.scala
@@ -90,8 +90,8 @@ object ParserSpec extends DefaultRunnableSpec {
             )(
               isRight(equalTo("123"))
             ),
-            parserTest("s <* s", Syntax.anyChar <~ Syntax.anyChar.printedAs((), '?'), "he")(isRight(equalTo('h'))),
-            parserTest("s *> s", Syntax.anyChar.printedAs((), '?') ~> Syntax.anyChar, "he")(isRight(equalTo('e'))),
+            parserTest("s <* s", Syntax.anyChar <~ Syntax.anyChar.asPrinted((), '?'), "he")(isRight(equalTo('h'))),
+            parserTest("s *> s", Syntax.anyChar.asPrinted((), '?') ~> Syntax.anyChar, "he")(isRight(equalTo('e'))),
             parserTest(
               "s | s, left passing",
               charA | charB,

--- a/zio-parser/src/test/scala/zio/parser/PrinterSpec.scala
+++ b/zio-parser/src/test/scala/zio/parser/PrinterSpec.scala
@@ -48,8 +48,8 @@ object PrinterSpec extends DefaultRunnableSpec {
         )(
           isLeft(equalTo("not a"))
         ),
-        printerTest("s <* s", Syntax.anyChar <~ Syntax.anyChar.printedAs((), '?'), 'x')(isRight(equalTo("x?"))),
-        printerTest("s *> s", Syntax.anyChar.printedAs((), '?') ~> Syntax.anyChar, 'x')(isRight(equalTo("?x"))),
+        printerTest("s <* s", Syntax.anyChar <~ Syntax.anyChar.asPrinted((), '?'), 'x')(isRight(equalTo("x?"))),
+        printerTest("s *> s", Syntax.anyChar.asPrinted((), '?') ~> Syntax.anyChar, 'x')(isRight(equalTo("?x"))),
         printerTest("s | s, left passing", charA | charB, 'a')(
           isRight(equalTo("a"))
         ),

--- a/zio-parser/src/test/scala/zio/parser/examples/JsonExample.scala
+++ b/zio-parser/src/test/scala/zio/parser/examples/JsonExample.scala
@@ -20,7 +20,7 @@ object JsonExample extends DefaultRunnableSpec {
   }
 
   val whitespace  = Syntax.charIn(' ', '\t', '\r', '\n')
-  val whitespaces = whitespace.*.printedAs((), Chunk(' '))
+  val whitespaces = whitespace.*.asPrinted((), Chunk(' '))
 
   val quote        = Syntax.char('\"')
   val escapedChar  = Syntax.charNotIn('\"') // TODO: real escaping support


### PR DESCRIPTION
Separated the two variants of `.as()`, this way it's less surprising i think:

`.as(result)` works as you would expect, maps the result to the new value
`.printedAs(result, value)` is a more special one that is useful on `Syntax` to drop a parsed value but in the same time specify how to print it. Like a whitespace parser can default to a single whitespace with `.printedAs((), Chunk(' '))` . I'm not completely satisfied with the name but at least now it is not called the same as `as` :) 