### PR TITLE
Fix handling of repeats and alternative options in Tabular

### DIFF
--- a/zio-parser/shared/src/main/scala/zio/parser/Regex.scala
+++ b/zio-parser/shared/src/main/scala/zio/parser/Regex.scala
@@ -441,21 +441,20 @@ object Regex {
           Step.Jump(second)
         }
 
-        def apply(char: Int): Step = {
+        def apply(char: Int): Step =
           first(char) ~ next
-        }
 
         val supportsEmpty: Boolean = first.supportsEmpty && second.supportsEmpty
       }
 
       /** A degenerate tabular result that can succeed without computing any input.
-       */
+        */
       case object Empty extends ComputedLookupFunction {
         def apply(char: Int): Step = Step.Error
         val supportsEmpty: Boolean = true
       }
 
-      final case class Table(parseChar: Chunk[Step])                      extends LookupFunction         { self =>
+      final case class Table(parseChar: Chunk[Step]) extends LookupFunction { self =>
         private[this] val len = parseChar.length
 
         val supportsEmpty: Boolean = false

--- a/zio-parser/shared/src/main/scala/zio/parser/Regex.scala
+++ b/zio-parser/shared/src/main/scala/zio/parser/Regex.scala
@@ -435,7 +435,7 @@ object Regex {
         val supportsEmpty: Boolean = left.supportsEmpty || right.supportsEmpty
       }
       final case class Seq(first: LookupFunction, second: LookupFunction) extends ComputedLookupFunction {
-        val next = if (second.supportsEmpty) {
+        private val next: Step = if (second.supportsEmpty) {
           Step.MatchedOrJump(second)
         } else {
           Step.Jump(second)

--- a/zio-parser/shared/src/test/scala/zio/parser/RegexSpec.scala
+++ b/zio-parser/shared/src/test/scala/zio/parser/RegexSpec.scala
@@ -174,7 +174,7 @@ object RegexSpec extends ZIOSpecDefault {
             val s = "abc" * len
             val r = Regex.string("abc").atMost(max).compile
 
-            val expected = math.min(len, max)*3
+            val expected = math.min(len, max) * 3
             assertTrue(r.test(0, s) == expected)
           }
         },

--- a/zio-parser/shared/src/test/scala/zio/parser/RegexSpec.scala
+++ b/zio-parser/shared/src/test/scala/zio/parser/RegexSpec.scala
@@ -174,10 +174,10 @@ object RegexSpec extends ZIOSpecDefault {
             val s = "abc" * len
             val r = Regex.string("abc").atMost(max).compile
 
-            val expected = math.min(len, max)
+            val expected = math.min(len, max)*3
             assertTrue(r.test(0, s) == expected)
           }
-        } @@ TestAspect.ignore, // TODO
+        },
         test("between") {
           check(Gen.int(0, 20), Gen.int(0, 20), Gen.int(0, 20)) { (len, a, b) =>
             val max = Math.max(a, b)
@@ -188,7 +188,7 @@ object RegexSpec extends ZIOSpecDefault {
             val expected = if (len >= min) Math.min(len, max) else Regex.NeedMoreInput
             assertTrue(r.test(0, s) == expected)
           }
-        } @@ TestAspect.ignore  // TODO
+        }
       ),
       suite("end of stream")(
         test("oneOf(a, b)") {


### PR DESCRIPTION
I have noticed that tests in `RegexSpec` for `atMost` and `between` were ignored and that they would fail. In this PR I attempt to make them green.

There were two bigger areas that I fixed.

1. Handling of the `|` operator between Steps. In the original version, combining anything with `Matched` would be a `Matched` state as well. This would, however, reduce alternatives like `aaa | aa | a` to the shortest possible sequence. To help with this, I "uncommented" the `MatchedOrJump` type and interpreted it as some kind of "checkpoint". If in the while loop in the implementation of `test` we encounter a `MatchedOrJump`, we set `returnV` to the current index but otherwise continue the loop. Combining `Matched with Jump(...)` in this case would resuld a `MatchedOrJump`.

2. Handling Empty matchers: The current implementation of `LookupFunction` can only tell if a character matches or not. It cannot tell if it can match without consuming any input. There is an `object Empty` which extends `Tabular`, but it cannot be combined with a `LookupFunction` currently (`Empty | lookup = lookup`). This will fail for uses of `atMost`, or generally `Repeat` where 0 matches are allowed as well. To fix this, I moved `Empty` under `LookupFunction` and introduced a `supportsEmpty` value to `LookupFunction`. Combining lookup functions sequentially where `supportsEmpty=true` will create `MatchedOrJump` steps as well.