### PR TITLE
Generic input

### DIFF
--- a/benchmarks/src/main/scala/zio/parser/benchmarks/ParserBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/parser/benchmarks/ParserBenchmark.scala
@@ -24,10 +24,12 @@ abstract class ParserBenchmark[T] {
   val parserz: Parserz.Grammar[Any, Nothing, String, T]
 
   var value: String = _
+  var valueAsChunk: Chunk[Char] = _
 
   @Setup
   def setUp(): Unit = {
     value = loadInput()
+    valueAsChunk = Chunk.fromArray(value.toCharArray)
     zioSyntax.parseString("")
   }
 
@@ -47,6 +49,12 @@ abstract class ParserBenchmark[T] {
   def zioParserRecursive(): Either[zio.parser.Parser.ParserError[String], T] = {
     import zio.parser._
     zioSyntax.parseString(value, ParserImplementation.Recursive)
+  }
+
+  @Benchmark
+  def zioParserRecursiveOnChunk(): Either[zio.parser.Parser.ParserError[String], T] = {
+    import zio.parser._
+    zioSyntax.parseChunk(valueAsChunk)
   }
 
   @Benchmark

--- a/benchmarks/src/main/scala/zio/parser/benchmarks/lucene/LuceneQueryBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/parser/benchmarks/lucene/LuceneQueryBenchmark.scala
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeUnit
 @Fork(value = 1)
 class LuceneQueryBenchmark {
   var testQuery: String                                         = _
+  var testQueryChunk: Chunk[Char]                               = _
   var catsParser: CatsLuceneQueryParser                         = _
   var zioParserQuery: Syntax[String, Char, Char, Query]         = _
   var zioParserStrippedQuery: Syntax[String, Char, Char, Query] = _
@@ -36,6 +37,7 @@ class LuceneQueryBenchmark {
   def setUp(): Unit = {
     testQuery =
       "status:(active OR pending) AND title:(full text search)^2 AND date:[2012-01-01 TO 2012-12-31] AND (quikc~ brwn~ foks~)"
+    testQueryChunk = Chunk.fromArray(testQuery.toCharArray)
 
     catsParser = new CatsLuceneQueryParser()
     val zioParser = new ZioLuceneQueryParser()
@@ -54,6 +56,10 @@ class LuceneQueryBenchmark {
   @Benchmark
   def zioParseStrippedRecursive(): Either[ParserError[String], Query] =
     zioParserStrippedQuery.parseString(testQuery, ParserImplementation.Recursive)
+
+  @Benchmark
+  def zioParseStrippedRecursiveChunk(): Either[ParserError[String], Query] =
+    zioParserStrippedQuery.parseChunk(testQueryChunk)
 
   @Benchmark
   def zioParseStrippedOpStack(): Either[ParserError[String], Query] =

--- a/benchmarks/src/main/scala/zio/parser/benchmarks/lucene/LuceneQueryBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/parser/benchmarks/lucene/LuceneQueryBenchmark.scala
@@ -64,19 +64,19 @@ class LuceneQueryBenchmark {
 //    zioParserStrippedQuery.parseChars(testQueryChunk, ParserImplementation.VM)
 }
 
-object LuceneQueryBenchmark extends LuceneQueryBenchmark {
-  def main(args: Array[String]): Unit = {
-    setUp()
-    Debug.printParserTree(zioParserQuery.asParser.optimized)
-    println("----")
-    Debug.printParserTree(zioParserStrippedQuery.asParser.optimized)
-    println(s"ZIO Parser result: ${zioParse()}")
-    println(s"ZIO Parser stripped result: ${zioParseStrippedRecursive()}")
-    println(s"ZIO Parser stripped op-stack result: ${zioParseStrippedOpStack()}")
-    println(s"Cats Parser result: ${catsParse()}")
-
-//    val builder = new VMBuilder
-//    builder.compile(zioParserQuery.asParser.asInstanceOf[ErasedParser])
-//    println(builder.result())
-  }
-}
+//object LuceneQueryBenchmark extends LuceneQueryBenchmark {
+//  def main(args: Array[String]): Unit = {
+//    setUp()
+//    Debug.printParserTree(zioParserQuery.asParser.optimized)
+//    println("----")
+//    Debug.printParserTree(zioParserStrippedQuery.asParser.optimized)
+//    println(s"ZIO Parser result: ${zioParse()}")
+//    println(s"ZIO Parser stripped result: ${zioParseStrippedRecursive()}")
+//    println(s"ZIO Parser stripped op-stack result: ${zioParseStrippedOpStack()}")
+//    println(s"Cats Parser result: ${catsParse()}")
+//
+////    val builder = new VMBuilder
+////    builder.compile(zioParserQuery.asParser.asInstanceOf[ErasedParser])
+////    println(builder.result())
+//  }
+//}

--- a/benchmarks/src/main/scala/zio/parser/benchmarks/micro/CharParserMicroBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/parser/benchmarks/micro/CharParserMicroBenchmarks.scala
@@ -88,13 +88,13 @@ class CharParserMicroBenchmarks {
     repeatWithSep0Syntax.parseString(hellosSep)
 }
 
-object CharParserMicroBenchmarks extends CharParserMicroBenchmarks {
-  def main(args: Array[String]): Unit = {
-    setUp()
-//    println(skipAndTransform())
-//    println(skipAndTransformOrElse())
-//    println(skipAndTransformRepeat())
-//    println(skipAndTransformZip())
-    println(repeatWithSep0().map(_.length))
-  }
-}
+//object CharParserMicroBenchmarks extends CharParserMicroBenchmarks {
+//  def main(args: Array[String]): Unit = {
+//    setUp()
+////    println(skipAndTransform())
+////    println(skipAndTransformOrElse())
+////    println(skipAndTransformRepeat())
+////    println(skipAndTransformZip())
+//    println(repeatWithSep0().map(_.length))
+//  }
+//}

--- a/zio-parser/shared/src/main/scala/zio/parser/Parser.scala
+++ b/zio-parser/shared/src/main/scala/zio/parser/Parser.scala
@@ -303,7 +303,9 @@ sealed trait Parser[+Err, -In, +Result] { self =>
     parseString(new String(input.toArray), parserImplementation)
 
   /** Run this parser on the given 'input' chunk */
-  final def parseChunk[In0 <: In](input: Chunk[In0])(implicit stateSelector: StateSelector[In0]): Either[ParserError[Err], Result] = {
+  final def parseChunk[In0 <: In](
+      input: Chunk[In0]
+  )(implicit stateSelector: StateSelector[In0]): Either[ParserError[Err], Result] = {
     val state  = recursive.ParserState.fromChunk(input)
     val result = self.optimized.parseRec(state)
 
@@ -593,7 +595,7 @@ object Parser {
       } else {
         state.position = result
         if (!state.discard) {
-          state.at(result - 1)
+          state.char(result - 1)
         } else null.asInstanceOf[Char]
       }
     }

--- a/zio-parser/shared/src/main/scala/zio/parser/Regex.scala
+++ b/zio-parser/shared/src/main/scala/zio/parser/Regex.scala
@@ -130,9 +130,13 @@ object Regex {
 
   trait Compiled {
 
-    /** Tests the compiled regex against the specified character sequence. Returns the new index into the chunk.
+    /** Tests the compiled regex against the specified character sequence. Returns the new index into the string.
       */
     def test(index: Int, chars: String): Int
+
+    /** Tests the compiled regex against the specified character sequence. Returns the new index into the chunk.
+      */
+    def test(index: Int, chars: Chunk[Char]): Int
 
     /** Determines if the compiled regex matches the specified string.
       */
@@ -166,8 +170,8 @@ object Regex {
     }
 
     def compile(regex: Regex): (Int, String) => Int =
-      regex.compileToTabular.map(compiled => compiled.test(_, _)).getOrElse {
-        BuiltIn(regex).map(compiled => compiled.test(_, _)).getOrElse {
+      regex.compileToTabular.map(compiled => compiled.test(_: Int, _: String)).getOrElse {
+        BuiltIn(regex).map(compiled => compiled.test(_: Int, _: String)).getOrElse {
           regex match {
             case Succeed => (idx: Int, _: String) => idx
 
@@ -246,12 +250,97 @@ object Regex {
         }
       }
 
+    def compileChunk(regex: Regex): (Int, Chunk[Char]) => Int =
+      regex.compileToTabular.map(compiled => compiled.test(_: Int, _: Chunk[Char])).getOrElse {
+        BuiltIn(regex).map(compiled => compiled.test(_: Int, _: Chunk[Char])).getOrElse {
+          regex match {
+            case Succeed => (idx: Int, _: Chunk[Char]) => idx
+
+            case oneOf@OneOf(_) =>
+              (idx: Int, input: Chunk[Char]) =>
+                if (idx >= input.length) NeedMoreInput else if (oneOf.contains(input(idx))) idx + 1 else NotMatched
+
+            case s@Sequence(_, _) =>
+              val compiled = Chunk.fromIterable(sequence(s).map(compileChunk(_)))
+
+              (idx0: Int, input: Chunk[Char]) => {
+                val compiledLen = compiled.length
+
+                var i = 0
+                var idx = idx0
+
+                while (i < compiledLen) {
+                  val current = compiled(i)
+
+                  idx = current(idx, input)
+
+                  if (idx < 0) i = compiledLen // Terminate loop because current parser didn't match
+                  else i = i + 1
+                }
+
+                idx
+              }
+
+            case Repeat(regex, min0, max0) =>
+              val min = min0.getOrElse(0)
+              val max = max0.getOrElse(Int.MaxValue)
+
+              val compiled = compileChunk(regex)
+
+              (idx0: Int, input: Chunk[Char]) => {
+                val len = input.length
+
+                var idx = idx0
+                var lastIdx = idx0
+                var matched = 0
+
+                while (idx >= 0 && idx < len && matched < max) {
+                  idx = compiled(idx, input)
+
+                  if (idx >= 0) {
+                    lastIdx = idx
+                    matched = matched + 1
+                  }
+                }
+
+                if (matched < min) NeedMoreInput else lastIdx
+              }
+
+            case Or(left0, right0) =>
+              val left = compileChunk(left0)
+              val right = compileChunk(right0)
+
+              (idx: Int, input: Chunk[Char]) =>
+                left(idx, input) match {
+                  case NotMatched => right(idx, input)
+                  case NeedMoreInput => right(idx, input)
+                  case idx => idx
+                }
+
+            case And(left0, right0) =>
+              val left = compileChunk(left0)
+              val right = compileChunk(right0)
+
+              (idx: Int, input: Chunk[Char]) =>
+                left(idx, input) match {
+                  case NotMatched => NotMatched
+                  case NeedMoreInput => NeedMoreInput
+                  case _ => right(idx, input)
+                }
+          }
+        }
+      }
+
     def apply(regex: Regex): Compiled =
       new Compiled {
         val compiled = compile(regex)
+        val compiledChunk = compileChunk(regex)
 
         def test(index: Int, input: String): Int =
           compiled(index, input)
+
+        override def test(index: Int, chars: Chunk[Char]): Int =
+          compiledChunk(index, chars)
       }
   }
 
@@ -411,7 +500,35 @@ object Regex {
           returnV
         }
       }
+
+      def test(index: Int, input: Chunk[Char]): Int = {
+        var curLookup = self
+        var curIdx    = index
+        val inputLen  = input.length
+        var returnV   = NeedMoreInput
+
+        while (curIdx < inputLen) {
+          val char = input(curIdx).toInt
+
+          curIdx = curIdx + 1
+
+          curLookup(char) match {
+            case Step.Matched                           => returnV = curIdx; curIdx = inputLen;
+            case Step.Error if returnV == NeedMoreInput => returnV = NotMatched; curIdx = inputLen;
+            case Step.Error                             => curIdx = inputLen;
+            case Step.Jump(lookup)                      => curLookup = lookup
+            case Step.MatchedOrJump(lookup)             => returnV = curIdx; curLookup = lookup;
+          }
+        }
+
+        if ((returnV == NeedMoreInput || returnV == NotMatched) && self.supportsEmpty) {
+          index
+        } else {
+          returnV
+        }
+      }
     }
+
     object LookupFunction {
       abstract class ComputedLookupFunction extends LookupFunction { self =>
         final def ~(that: LookupFunction): LookupFunction = LookupFunction.Seq(self, that)
@@ -616,6 +733,9 @@ object Regex {
           Regex.NotMatched
         }
       }
+
+      override def test(index: Int, chars: Chunk[Char]): Int =
+        throw new UnsupportedOperationException("BuiltIn regexes are not supported on Chunk[Char]")
     }
   }
 }

--- a/zio-parser/shared/src/main/scala/zio/parser/Regex.scala
+++ b/zio-parser/shared/src/main/scala/zio/parser/Regex.scala
@@ -256,17 +256,17 @@ object Regex {
           regex match {
             case Succeed => (idx: Int, _: Chunk[Char]) => idx
 
-            case oneOf@OneOf(_) =>
+            case oneOf @ OneOf(_) =>
               (idx: Int, input: Chunk[Char]) =>
                 if (idx >= input.length) NeedMoreInput else if (oneOf.contains(input(idx))) idx + 1 else NotMatched
 
-            case s@Sequence(_, _) =>
+            case s @ Sequence(_, _) =>
               val compiled = Chunk.fromIterable(sequence(s).map(compileChunk(_)))
 
               (idx0: Int, input: Chunk[Char]) => {
                 val compiledLen = compiled.length
 
-                var i = 0
+                var i   = 0
                 var idx = idx0
 
                 while (i < compiledLen) {
@@ -290,7 +290,7 @@ object Regex {
               (idx0: Int, input: Chunk[Char]) => {
                 val len = input.length
 
-                var idx = idx0
+                var idx     = idx0
                 var lastIdx = idx0
                 var matched = 0
 
@@ -307,25 +307,25 @@ object Regex {
               }
 
             case Or(left0, right0) =>
-              val left = compileChunk(left0)
+              val left  = compileChunk(left0)
               val right = compileChunk(right0)
 
               (idx: Int, input: Chunk[Char]) =>
                 left(idx, input) match {
-                  case NotMatched => right(idx, input)
+                  case NotMatched    => right(idx, input)
                   case NeedMoreInput => right(idx, input)
-                  case idx => idx
+                  case idx           => idx
                 }
 
             case And(left0, right0) =>
-              val left = compileChunk(left0)
+              val left  = compileChunk(left0)
               val right = compileChunk(right0)
 
               (idx: Int, input: Chunk[Char]) =>
                 left(idx, input) match {
-                  case NotMatched => NotMatched
+                  case NotMatched    => NotMatched
                   case NeedMoreInput => NeedMoreInput
-                  case _ => right(idx, input)
+                  case _             => right(idx, input)
                 }
           }
         }
@@ -333,7 +333,7 @@ object Regex {
 
     def apply(regex: Regex): Compiled =
       new Compiled {
-        val compiled = compile(regex)
+        val compiled      = compile(regex)
         val compiledChunk = compileChunk(regex)
 
         def test(index: Int, input: String): Int =

--- a/zio-parser/shared/src/main/scala/zio/parser/Syntax.scala
+++ b/zio-parser/shared/src/main/scala/zio/parser/Syntax.scala
@@ -396,7 +396,9 @@ class Syntax[+Err, -In, +Out, Value] private (
   ): Either[ParserError[Err], Value] = asParser.parseChars(input, parserImplementation)
 
   /** Run this parser on the given 'input' chunk */
-  final def parseChunk[In0 <: In](input: Chunk[In0])(implicit stateSelector: StateSelector[In0]): Either[ParserError[Err], Value] =
+  final def parseChunk[In0 <: In](input: Chunk[In0])(implicit
+      stateSelector: StateSelector[In0]
+  ): Either[ParserError[Err], Value] =
     asParser.parseChunk(input)
 
   /** Prints a value 'value' to the target implementation 'target' */

--- a/zio-parser/shared/src/main/scala/zio/parser/Syntax.scala
+++ b/zio-parser/shared/src/main/scala/zio/parser/Syntax.scala
@@ -2,6 +2,7 @@ package zio.parser
 
 import zio.Chunk
 import zio.parser.Parser.ParserError
+import zio.parser.internal.recursive.ParserState.StateSelector
 import zio.parser.target.Target
 
 /** Syntax defines a parser and a printer together and provides combinators to simultaneously build them up from smaller
@@ -395,7 +396,7 @@ class Syntax[+Err, -In, +Out, Value] private (
   ): Either[ParserError[Err], Value] = asParser.parseChars(input, parserImplementation)
 
   /** Run this parser on the given 'input' chunk */
-  final def parseChunk(input: Chunk[In]): Either[ParserError[Err], Value] =
+  final def parseChunk[In0 <: In](input: Chunk[In0])(implicit stateSelector: StateSelector[In0]): Either[ParserError[Err], Value] =
     asParser.parseChunk(input)
 
   /** Prints a value 'value' to the target implementation 'target' */

--- a/zio-parser/shared/src/main/scala/zio/parser/Syntax.scala
+++ b/zio-parser/shared/src/main/scala/zio/parser/Syntax.scala
@@ -394,6 +394,10 @@ class Syntax[+Err, -In, +Out, Value] private (
       ev: Char <:< In
   ): Either[ParserError[Err], Value] = asParser.parseChars(input, parserImplementation)
 
+  /** Run this parser on the given 'input' chunk */
+  final def parseChunk(input: Chunk[In]): Either[ParserError[Err], Value] =
+    asParser.parseChunk(input)
+
   /** Prints a value 'value' to the target implementation 'target' */
   final def print[Out2 >: Out](value: Value, target: Target[Out2]): Either[Err, Unit] =
     asPrinter.print(value, target)

--- a/zio-parser/shared/src/main/scala/zio/parser/internal/recursive/ParserState.scala
+++ b/zio-parser/shared/src/main/scala/zio/parser/internal/recursive/ParserState.scala
@@ -16,6 +16,9 @@ sealed trait ParserState[+In] {
   def at(pos: Int): In
   val length: Int
 
+  def char(index: Int)(implicit ev: In <:< Char): Char =
+    ev(at(index))
+
   /** Position in the parsed string (source) */
   var position: Int = 0
 
@@ -44,7 +47,6 @@ object ParserState {
 
     override def sliceToChunk(pos: Int, until: Int): Chunk[Char] =
       Chunk.fromArray(source.slice(pos, until).toCharArray)
-
 
     override def sliceToString(pos: Int, until: Int): String =
       source.slice(pos, until)

--- a/zio-parser/shared/src/main/scala/zio/parser/internal/recursive/ParserState.scala
+++ b/zio-parser/shared/src/main/scala/zio/parser/internal/recursive/ParserState.scala
@@ -9,7 +9,7 @@ import zio.parser.Parser.ParserError
   * @param source
   *   The parsed string
   */
-final class ParserState(val source: String) {
+final class ParserState[+Source](val source: Source) {
 
   /** Position in the parsed string (source) */
   var position: Int = 0

--- a/zio-parser/shared/src/main/scala/zio/parser/internal/recursive/ParserState.scala
+++ b/zio-parser/shared/src/main/scala/zio/parser/internal/recursive/ParserState.scala
@@ -1,15 +1,20 @@
 package zio.parser.internal.recursive
 
+import zio.Chunk
 import zio.parser.Parser.ParserError
+import zio.parser.Regex
 
 /** State of the recursive parser implementation
   *
   * The implementation itself is in Parser#parseRec.
-  *
-  * @param source
-  *   The parsed string
   */
-final class ParserState[+Source](val source: Source) {
+sealed trait ParserState[+In] {
+
+  def regex(compiledRegex: Regex.Compiled): Int
+  def sliceToChunk(pos: Int, until: Int): Chunk[In]
+  def sliceToString(pos: Int, until: Int): String
+  def at(pos: Int): In
+  val length: Int
 
   /** Position in the parsed string (source) */
   var position: Int = 0
@@ -30,4 +35,70 @@ final class ParserState[+Source](val source: Source) {
   /** Pop the last pushed name from nameStack */
   def popName(): Unit =
     nameStack = nameStack.tail
+}
+
+object ParserState {
+  private final class StringParserState(source: String) extends ParserState[Char] {
+    override def regex(compiledRegex: Regex.Compiled): Int =
+      compiledRegex.test(position, source)
+
+    override def sliceToChunk(pos: Int, until: Int): Chunk[Char] =
+      Chunk.fromArray(source.slice(pos, until).toCharArray)
+
+
+    override def sliceToString(pos: Int, until: Int): String =
+      source.slice(pos, until)
+
+    override def at(pos: Int): Char = source(pos)
+
+    override val length: Int = source.length
+  }
+
+  private final class CharChunkParserState(source: Chunk[Char]) extends ParserState[Char] {
+    override def regex(compiledRegex: Regex.Compiled): Int =
+      compiledRegex.test(position, source)
+
+    override def sliceToChunk(pos: Int, until: Int): Chunk[Char] =
+      source.slice(pos, until)
+
+    override def sliceToString(pos: Int, until: Int): String =
+      new String(source.slice(pos, until).toArray)
+
+    override def at(pos: Int): Char = source(pos)
+
+    override val length: Int = source.length
+  }
+
+  private final class ChunkParserState[In](source: Chunk[In]) extends ParserState[In] {
+    override def regex(compiledRegex: Regex.Compiled): Int =
+      throw new UnsupportedOperationException("regex not supported on non-char Chunks")
+
+    override def sliceToChunk(pos: Int, until: Int): Chunk[In] =
+      source.slice(pos, until)
+
+    override def sliceToString(pos: Int, until: Int): String =
+      throw new UnsupportedOperationException("sliceToString not supported on non-char Chunks")
+
+    override def at(pos: Int): In = source(pos)
+
+    override val length: Int = source.length
+  }
+
+  def fromString(source: String): ParserState[Char] =
+    new StringParserState(source)
+
+  def fromChunk[In](chunk: Chunk[In])(implicit stateSelector: StateSelector[In]): ParserState[In] =
+    stateSelector.create(chunk)
+
+  trait StateSelector[In] {
+    def create(chunk: Chunk[In]): ParserState[In]
+  }
+
+  object StateSelector extends LowerPriorityStateSelector {
+    implicit val charStateSelector: StateSelector[Char] = (chunk: Chunk[Char]) => new CharChunkParserState(chunk)
+  }
+
+  trait LowerPriorityStateSelector {
+    implicit def otherStateSelector[In]: StateSelector[In] = (chunk: Chunk[In]) => new ChunkParserState(chunk)
+  }
 }


### PR DESCRIPTION
Resolves #43 

Reenables parsing from arbitrary `Chunk[In]` while keeps the specialized `String` input support as well as it provides a bit better performance.