### PR TITLE
Include position in NotConsumedAll error

### DIFF
--- a/zio-parser/shared/src/main/scala/zio/parser/Parser.scala
+++ b/zio-parser/shared/src/main/scala/zio/parser/Parser.scala
@@ -1267,7 +1267,7 @@ object Parser {
 
     override protected def parseRec(state: ParserState[Any]): Unit =
       if (state.position < state.length)
-        state.error = ParserError.NotConsumedAll(None)
+        state.error = ParserError.NotConsumedAll(state.nameStack, state.position)
 
     override protected def needsBacktrack: Boolean = false
   }
@@ -1392,7 +1392,7 @@ object Parser {
       case ParserError.Failure(nameStack, position, failure) => ParserError.Failure(nameStack, position, f(failure))
       case ParserError.UnknownFailure(nameStack, position)   => ParserError.UnknownFailure(nameStack, position)
       case ParserError.UnexpectedEndOfInput                  => ParserError.UnexpectedEndOfInput
-      case ParserError.NotConsumedAll(lastFailure)           => ParserError.NotConsumedAll(lastFailure.map(_.map(f)))
+      case ParserError.NotConsumedAll(nameStack, position)   => ParserError.NotConsumedAll(nameStack, position)
       case ParserError.AllBranchesFailed(left, right)        => ParserError.AllBranchesFailed(left.map(f), right.map(f))
     }
   }
@@ -1430,7 +1430,7 @@ object Parser {
       * @param lastFailure
       *   the last encountered failure, if any
       */
-    final case class NotConsumedAll[Err](lastFailure: Option[ParserError[Err]]) extends ParserError[Err]
+    final case class NotConsumedAll[Err](nameStack: List[String], position: Int) extends ParserError[Err]
 
     /** All branches failed in a sequence of orElse or orElseEither parsers.
       *

--- a/zio-parser/shared/src/main/scala/zio/parser/internal/stacksafe/CharParserImpl.scala
+++ b/zio-parser/shared/src/main/scala/zio/parser/internal/stacksafe/CharParserImpl.scala
@@ -121,7 +121,7 @@ final class CharParserImpl[Err, Result](parser: InitialParser, source: String) {
         case CheckEnd()                              =>
           if (position < source.length) {
             lastSuccess1 = null
-            lastFailure1 = ParserError.NotConsumedAll(None)
+            lastFailure1 = ParserError.NotConsumedAll(nameStack, position)
           } else {
             lastSuccess1 = ().asInstanceOf[AnyRef]: @nowarn
             lastFailure1 = null

--- a/zio-parser/shared/src/test/scala/zio/parser/ParserSpec.scala
+++ b/zio-parser/shared/src/test/scala/zio/parser/ParserSpec.scala
@@ -29,7 +29,7 @@ object ParserSpec extends ZIOSpecDefault {
               isRight(equalTo("hello"))
             ),
             parserTest("end, failing", Syntax.digit.repeat0.string <~ Syntax.end, "123!!!")(
-              isLeft(equalTo(ParserError.NotConsumedAll(None)))
+              isLeft(equalTo(ParserError.NotConsumedAll(Nil, 3)))
             ),
             parserTest("char, passing", Syntax.char('x'), "x")(isRight(equalTo(()))),
             parserTest("char, failing", Syntax.char('y'), "x")(


### PR DESCRIPTION
Currently the error has a `lastFailure` parameter, but it is always set to `None`, and I couldn't think of a case where it could be filled. In case of previous errors, the parser should probably fail earlier.

I think it would be useful to add position information instead, to be able to show the location of the failure and the extra part of the input in the error message.

Closes #192 