### PR TITLE
Add pretty errors

### DIFF
--- a/benchmarks/src/main/scala/zio/parser/benchmarks/ParserBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/parser/benchmarks/ParserBenchmark.scala
@@ -46,7 +46,7 @@ abstract class ParserBenchmark[T] {
 //  }
 
   @Benchmark
-  def zioParserRecursive(): Either[zio.parser.Parser.ParserError[String], T] = {
+  def zioParserRecursive(): Either[zio.parser.StringParserError[String], T] = {
     import zio.parser._
     zioSyntax.parseString(value, ParserImplementation.Recursive)
   }
@@ -58,7 +58,7 @@ abstract class ParserBenchmark[T] {
   }
 
   @Benchmark
-  def zioParserOpStack(): Either[zio.parser.Parser.ParserError[String], T] = {
+  def zioParserOpStack(): Either[zio.parser.StringParserError[String], T] = {
     import zio.parser._
     zioSyntax.parseString(value, ParserImplementation.StackSafe)
   }

--- a/benchmarks/src/main/scala/zio/parser/benchmarks/lucene/LuceneQueryBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/parser/benchmarks/lucene/LuceneQueryBenchmark.scala
@@ -15,6 +15,7 @@ import org.openjdk.jmh.annotations.{
 }
 import zio.Chunk
 import zio.parser.{ParserImplementation, Syntax}
+import zio.parser.StringParserError
 import zio.parser.Parser.ParserError
 import zio.parser.internal.Debug
 
@@ -50,11 +51,11 @@ class LuceneQueryBenchmark {
     catsParser.query.parseAll(testQuery)
 
   @Benchmark
-  def zioParse(): Either[ParserError[String], Query] =
+  def zioParse(): Either[StringParserError[String], Query] =
     zioParserQuery.parseString(testQuery)
 
   @Benchmark
-  def zioParseStrippedRecursive(): Either[ParserError[String], Query] =
+  def zioParseStrippedRecursive(): Either[StringParserError[String], Query] =
     zioParserStrippedQuery.parseString(testQuery, ParserImplementation.Recursive)
 
   @Benchmark
@@ -62,7 +63,7 @@ class LuceneQueryBenchmark {
     zioParserStrippedQuery.parseChunk(testQueryChunk)
 
   @Benchmark
-  def zioParseStrippedOpStack(): Either[ParserError[String], Query] =
+  def zioParseStrippedOpStack(): Either[StringParserError[String], Query] =
     zioParserStrippedQuery.parseString(testQuery, ParserImplementation.StackSafe)
 
 //  @Benchmark

--- a/benchmarks/src/main/scala/zio/parser/benchmarks/micro/CharParserMicroBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/parser/benchmarks/micro/CharParserMicroBenchmarks.scala
@@ -13,6 +13,7 @@ import org.openjdk.jmh.annotations.{
   Warmup
 }
 import zio.Chunk
+import zio.parser.StringParserError
 import zio.parser.Parser.ParserError
 import zio.parser.{Regex, Syntax}
 
@@ -68,23 +69,23 @@ class CharParserMicroBenchmarks {
   }
 
   @Benchmark
-  def skipAndTransform(): Either[ParserError[Nothing], String] =
+  def skipAndTransform(): Either[StringParserError[Nothing], String] =
     skipAndTransformSyntax.parseChars(hello)
 
   @Benchmark
-  def skipAndTransformOrElse(): Either[ParserError[String], String] =
+  def skipAndTransformOrElse(): Either[StringParserError[String], String] =
     skipAndTransformOrElseSyntax.parseChars(world)
 
   @Benchmark
-  def skipAndTransformRepeat(): Either[ParserError[String], Chunk[String]] =
+  def skipAndTransformRepeat(): Either[StringParserError[String], Chunk[String]] =
     skipAndTransformRepeatSyntax.parseChars(hellos)
 
   @Benchmark
-  def skipAndTransformZip(): Either[ParserError[String], String10] =
+  def skipAndTransformZip(): Either[StringParserError[String], String10] =
     skipAndTransformZipSyntax.parseChars(hellos)
 
   @Benchmark
-  def repeatWithSep0(): Either[ParserError[String], Chunk[String]] =
+  def repeatWithSep0(): Either[StringParserError[String], Chunk[String]] =
     repeatWithSep0Syntax.parseString(hellosSep)
 }
 

--- a/zio-parser-caliban/src/main/scala/zio/parser/caliban/CalibanParser.scala
+++ b/zio-parser-caliban/src/main/scala/zio/parser/caliban/CalibanParser.scala
@@ -911,7 +911,7 @@ object CalibanDemo extends ZIOAppDefault {
 (id: "1000", int: 3, float: 3.14, bool: true, nope: null, enum: YES, list: [1,2,3])
 """.trim
 
-  val parsed: ZIO[Any, Nothing, Either[Parser.ParserError[String], StringValue]] =
+  val parsed: ZIO[Any, Nothing, Either[StringParserError[String], StringValue]] =
     ZIO
       .succeed(CalibanParser.stringValue.parseString(query))
       //  val parsed = UIO(CalibanSyntax.stringValue.parse("\"\"\"hello\"\"\""))

--- a/zio-parser/shared/src/main/scala/zio/parser/Syntax.scala
+++ b/zio-parser/shared/src/main/scala/zio/parser/Syntax.scala
@@ -384,23 +384,23 @@ class Syntax[+Err, -In, +Out, Value] private (
     )
 
   /** Run this parser on the given 'input' string */
-  final def parseString(input: String)(implicit ev: Char <:< In): Either[ParserError[Err], Value] =
+  final def parseString(input: String)(implicit ev: Char <:< In): Either[StringParserError[Err], Value] =
     asParser.parseString(input)
 
   /** Run this parser on the given 'input' string using a specific parser implementation */
   final def parseString(input: String, parserImplementation: ParserImplementation)(implicit
       ev: Char <:< In
-  ): Either[ParserError[Err], Value] =
+  ): Either[StringParserError[Err], Value] =
     asParser.parseString(input, parserImplementation)
 
   /** Run this parser on the given 'input' chunk of characters */
-  final def parseChars(input: Chunk[Char])(implicit ev: Char <:< In): Either[ParserError[Err], Value] =
+  final def parseChars(input: Chunk[Char])(implicit ev: Char <:< In): Either[StringParserError[Err], Value] =
     asParser.parseChars(input)
 
   /** Run this parser on the given 'input' chunk of characters using a specific parser implementation */
   final def parseChars(input: Chunk[Char], parserImplementation: ParserImplementation)(implicit
       ev: Char <:< In
-  ): Either[ParserError[Err], Value] = asParser.parseChars(input, parserImplementation)
+  ): Either[StringParserError[Err], Value] = asParser.parseChars(input, parserImplementation)
 
   /** Run this parser on the given 'input' chunk */
   final def parseChunk[In0 <: In](input: Chunk[In0])(implicit

--- a/zio-parser/shared/src/main/scala/zio/parser/internal/stacksafe/CharParserImpl.scala
+++ b/zio-parser/shared/src/main/scala/zio/parser/internal/stacksafe/CharParserImpl.scala
@@ -138,7 +138,7 @@ final class CharParserImpl[Err, Result](parser: InitialParser, source: String) {
             position = position + 1
             lastSuccess1 = source(position - 1).asInstanceOf[AnyRef]
           } else {
-            lastFailure1 = ParserError.UnexpectedEndOfInput
+            lastFailure1 = ParserError.UnexpectedEndOfInput(nameStack)
           }
           opStack.pop()
 
@@ -157,7 +157,7 @@ final class CharParserImpl[Err, Result](parser: InitialParser, source: String) {
                 )
               }
             } else {
-              failure = ParserError.UnexpectedEndOfInput
+              failure = ParserError.UnexpectedEndOfInput(nameStack)
             }
             pos = pos + 1
           }
@@ -174,7 +174,7 @@ final class CharParserImpl[Err, Result](parser: InitialParser, source: String) {
         case MatchRegex(regex, pushAs, failAs) =>
           val result = regex.test(position, source)
           if (result == Regex.NeedMoreInput) {
-            lastFailure1 = ParserError.UnexpectedEndOfInput
+            lastFailure1 = ParserError.UnexpectedEndOfInput(nameStack)
           } else if (result == Regex.NotMatched) {
             failAs match {
               case Some(failure) =>
@@ -355,7 +355,7 @@ final class CharParserImpl[Err, Result](parser: InitialParser, source: String) {
             val result = builder.result()
             if (result.length < min) {
               // not enough elements
-              lastFailure1 = ParserError.UnexpectedEndOfInput
+              lastFailure1 = ParserError.UnexpectedEndOfInput(nameStack)
               opStack.pop()
             } else {
               lastIgnoredError = lastFailure1

--- a/zio-parser/shared/src/test/scala/zio/parser/ParserSpec.scala
+++ b/zio-parser/shared/src/test/scala/zio/parser/ParserSpec.scala
@@ -197,7 +197,7 @@ object ParserSpec extends ZIOSpecDefault {
                 isLeft(equalTo(ParserError.Failure(Nil, 0, "not a")))
               ) @@ TestAspect.ignore, // With compiling to Regex it fails with UnexpectedEndOfInput - to be discussed
               parserTest("repeat immediate end of stream", Syntax.char('a', "not a").repeat, "")(
-                isLeft(equalTo(ParserError.UnexpectedEndOfInput))
+                isLeft(equalTo(ParserError.UnexpectedEndOfInput(Nil)))
               ),
               parserTest("repeat 1", charA.repeat, "abc")(
                 isRight(equalTo(Chunk('a')))
@@ -412,7 +412,7 @@ object ParserSpec extends ZIOSpecDefault {
                 isRight(equalTo("123"))
               ),
               parserTest("digits, failing", Syntax.digit.+.string, "abc123")(
-                isLeft(equalTo(ParserError.UnexpectedEndOfInput))
+                isLeft(equalTo(ParserError.UnexpectedEndOfInput(Nil)))
               )
             ),
             parserTest("Not, inner failing", Syntax.string("hello", ()).not("it was hello"), "world")(
@@ -461,7 +461,7 @@ object ParserSpec extends ZIOSpecDefault {
   ): Spec[Any, Nothing] =
     test(name) {
 //      Debug.printParserTree(syntax.asParser.optimized)
-      assert(syntax.parseString(input, implementation))(assertion)
+      assert(syntax.parseString(input, implementation).left.map(_.error))(assertion)
     }
 
   private def createParserTest_[E, T](
@@ -470,7 +470,7 @@ object ParserSpec extends ZIOSpecDefault {
       assertion: Assertion[Either[ParserError[E], T]]
   ): Spec[Any, Nothing] =
     test(name)(
-      assert(parser.parseString(input, implementation))(assertion)
+      assert(parser.parseString(input, implementation).left.map(_.error))(assertion)
     )
 //    test(name)(assert(syntax.parseString(input))(assertion))
 }

--- a/zio-parser/shared/src/test/scala/zio/parser/StringParserErrorSpec.scala
+++ b/zio-parser/shared/src/test/scala/zio/parser/StringParserErrorSpec.scala
@@ -1,0 +1,113 @@
+package zio.parser
+
+import zio.test.Assertion._
+import zio.test._
+
+object StringParserErrorSpec extends ZIOSpecDefault {
+  override def spec =
+    suite("StringParserError")(
+      failureTest(
+        "should pretty print a Failure error",
+        Syntax.char('y'),
+        "x",
+        """|x
+           |^
+           |error: Failure at position 0: not 'y'
+           |""".stripMargin
+      ),
+      failureTest(
+        "should pretty print an UnexpectedEndOfInput error",
+        Syntax.char('y'),
+        "",
+        "Unexpected end of input"
+      ),
+      failureTest(
+        "should pretty print a NotConsumedAll error",
+        Syntax.char('y') <~ Syntax.end,
+        "yyz",
+        """|yyz
+           | ^
+           |error: Parser did not consume all input at position 1
+           |""".stripMargin
+      ),
+      failureTest(
+        "should pretty print an AllBranchesFailed error",
+        Syntax.char('y').orElse(Syntax.char('z')),
+        "x",
+        "All branches failed: Failure at position 0: not 'y' and Failure at position 0: not 'z'"
+      ),
+      failureTest(
+        "should pretty print an error with multiline input",
+        Syntax.char('y'),
+        "x\ny",
+        """|x
+           |^
+           |error: Failure at position 0: not 'y'
+           |y
+           |""".stripMargin
+      ),
+      failureTest(
+        "should point to the correct position in the input",
+        Syntax.char('x').repeat <~ Syntax.end,
+        "xxxyxx",
+        """|xxxyxx
+           |   ^
+           |error: Parser did not consume all input at position 3
+           |""".stripMargin
+      ),
+      failureTest(
+        "should replace the following lines with an ellipsis",
+        Syntax.char('y'),
+        "x\n" + "y\n" * 100,
+        """|x
+           |^
+           |error: Failure at position 0: not 'y'
+           |y
+           |y
+           |...
+           |""".stripMargin
+      ),
+      failureTest(
+        "should replace the preceding and following lines with an ellipsis",
+        (Syntax.digit.orElse(Syntax.whitespace)).repeat <~ Syntax.end,
+        "1\n1\n1\n" + "y\n" + "1\n1\n1\n",
+        """|...
+           |1
+           |1
+           |y
+           |^
+           |error: Parser did not consume all input at position 6
+           |1
+           |1
+           |...
+           |""".stripMargin
+      ),
+      failureTest(
+        "should print the failed parser name",
+        (Syntax.digit.named("digit").orElse(Syntax.whitespace.named("whitespace"))).repeat <~
+          Syntax.end.named("end"),
+        "1 1 1 1 y 1 1 1",
+        """|1 1 1 1 y 1 1 1
+           |        ^
+           |error: Parser did not consume all input at position 8 in end
+           |""".stripMargin
+      ),
+      failureTest(
+        "should print the parser name stack",
+        ((Syntax.digit.named("digit") ~ Syntax.string("Keyword", ()).named("keyword"))
+          .named("combined")),
+        "5Keywor",
+        "Unexpected end of input in keyword -> combined"
+      )
+    )
+
+  private def failureTest[E, T](
+      name: String,
+      parser: Syntax[E, Char, Char, T],
+      input: String,
+      expectedErrorMessage: String
+  ): Spec[Any, TestFailure[Nothing]] =
+    test(name) {
+      assert(parser.parseString(input).left.map(_.pretty))(isLeft(equalTo(expectedErrorMessage)))
+    }
+}

--- a/zio-parser/shared/src/test/scala/zio/parser/SyntaxSpec.scala
+++ b/zio-parser/shared/src/test/scala/zio/parser/SyntaxSpec.scala
@@ -81,7 +81,7 @@ object SyntaxSpec extends ZIOSpecDefault {
       },
       test("oneOf fails to parse garbage") {
         val parsed = WeekDay.weekDaySyntax.parseString("garbage")
-        assert(parsed)(isLeft(isSubtype[AllBranchesFailed[String]](anything)))
+        assert(parsed.left.map(_.error))(isLeft(isSubtype[AllBranchesFailed[String]](anything)))
       }
     )
 }

--- a/zio-parser/shared/src/test/scala/zio/parser/examples/ContextualExample.scala
+++ b/zio-parser/shared/src/test/scala/zio/parser/examples/ContextualExample.scala
@@ -75,7 +75,7 @@ object ContextualExample extends ZIOSpecDefault {
           )
         },
         test("parse wrong") {
-          assert(node.parseString("<hello></world>"))(
+          assert(node.parseString("<hello></world>").left.map(_.error))(
             isLeft(equalTo(ParserError.Failure(List("close tag (hello)"), 7, "Not '</hello>'")))
           )
         },


### PR DESCRIPTION
Add pretty error messages indicating the position of the error in the input. Currently implemented for `parseString`/`parseChars` only.