### PR TITLE
Remove unnecessary type param from `transformTo`

### DIFF
--- a/zio-parser/shared/src/main/scala/zio/parser/Syntax.scala
+++ b/zio-parser/shared/src/main/scala/zio/parser/Syntax.scala
@@ -78,7 +78,7 @@ class Syntax[+Err, -In, +Out, Value] private (
     *
     * This can be used to define separate syntaxes for subtypes, that can be later combined.
     */
-  final def transformTo[Err2 >: Err, Value2, Result2](
+  final def transformTo[Err2 >: Err, Value2](
       to: Value => Value2,
       from: PartialFunction[Value2, Value],
       failure: Err2

--- a/zio-parser/shared/src/test/scala/zio/parser/examples/ExpressionExample.scala
+++ b/zio-parser/shared/src/test/scala/zio/parser/examples/ExpressionExample.scala
@@ -18,20 +18,20 @@ object ExpressionExample extends ZIOSpecDefault {
     .filter[String, Char](_.isDigit, "not a digit")
     .repeat
     .string
-    .transformTo[String, Expr, Expr](
+    .transformTo[String, Expr](
       s => Const(s.toInt),
       { case (n: Const) => n.value.toString },
       "Not a constant"
     ) ?? "constant"
   val operator: Syntax[String, Char, Char, OpType] =
-    (Syntax.charIn('+').transformTo[String, OpType, OpType](_ => Add, { case Add => '+' }, "Not +") <>
-      Syntax.charIn('-').transformTo[String, OpType, OpType](_ => Sub, { case Sub => '-' }, "Not -")) ?? "operator"
+    (Syntax.charIn('+').transformTo[String, OpType](_ => Add, { case Add => '+' }, "Not +") <>
+      Syntax.charIn('-').transformTo[String, OpType](_ => Sub, { case Sub => '-' }, "Not -")) ?? "operator"
   val lparen: Syntax[String, Char, Char, Unit]     = Syntax.char('(')
   val rparen: Syntax[String, Char, Char, Unit]     = Syntax.char(')')
 
   lazy val subExpr: Syntax[String, Char, Char, Expr] =
     (expr ~ operator ~ expr)
-      .transformTo[String, Expr, Expr](
+      .transformTo[String, Expr](
         { case (a, op, b) =>
           Op(op, a, b)
         },


### PR DESCRIPTION
Removed unused type param `Result2` from `Syntax#transformTo`.

Maybe we need v0.2.0 release due to the source incompatibility.