### PR TITLE
CI: Add JDK 21 and JDK 25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: ['17']
+        java: ['17', '21', '25']
         scala: ['212', '213', '3']
         platform: ['JVM', 'JS', 'Native']
     steps:


### PR DESCRIPTION
## Summary
- Add JDK 21 and JDK 25 to the CI test matrix
- Test matrix is now: JDK 17, 21, 25